### PR TITLE
Libs dependencies reducing

### DIFF
--- a/build-and-publish.sh
+++ b/build-and-publish.sh
@@ -18,7 +18,7 @@ yarn lint &&
 rm -rf dist/* &&
 # version update error ignoring because
 # there may be unpublished packages with updated version
-(./node_modules/.bin/lerna version --conventional-commits --yes --allow-branch master || true) &&
+(./node_modules/.bin/lerna version --conventional-commits --yes --allow-branch --exact master || true) &&
 yarn run build:all-libs &&
 yarn run test:libs &&
 

--- a/build-and-publish.sh
+++ b/build-and-publish.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 
+branch="$(git symbolic-ref --short -q HEAD)"
+
+if [ "$branch" != "master" ]; then
+    echo -e "\033[0;31m";
+    echo "╔════════════════════════════════════════════════╗"
+    echo "║ Publication MUST be run only in master branch! ║"
+    echo "║                                                ║"
+    echo "║ Please, make Pull Request in master branch and ║"
+    echo "║ continue publishing after PR merging.          ║"
+    echo "╚════════════════════════════════════════════════╝"
+    echo -e "\033[0m";
+    exit 1;
+fi
+
 yarn lint &&
 rm -rf dist/* &&
 # version update error ignoring because
 # there may be unpublished packages with updated version
-(./node_modules/.bin/lerna version --conventional-commits || true) &&
+(./node_modules/.bin/lerna version --conventional-commits --yes --allow-branch master || true) &&
 yarn run build:all-libs &&
 yarn run test:libs &&
 

--- a/libs/ng-api-service/package.json
+++ b/libs/ng-api-service/package.json
@@ -34,17 +34,17 @@
     "prettier": ">= 1"
   },
   "devDependencies": {
-    "@types/lodash": ">= 4",
-    "@types/node": ">= 8",
-    "jest-preset-angular": ">= 7"
-  },
-  "optionalDependencies": {
     "@angular/common": ">= 6",
     "@angular/core": ">= 6",
     "@angular/platform-browser-dynamic": ">= 6",
-    "@microsoft/typescript-etw": "*",
+    "@types/lodash": ">= 4",
+    "@types/node": ">= 8",
     "core-js": "*",
+    "jest-preset-angular": ">= 7",
     "rxjs": ">= 6",
     "zone.js": ">= 0"
+  },
+  "optionalDependencies": {
+    "@microsoft/typescript-etw": "*"
   }
 }

--- a/libs/oapi3ts/package.json
+++ b/libs/oapi3ts/package.json
@@ -30,20 +30,20 @@
     "prettier": ">= 1"
   },
   "devDependencies": {
-    "jest-preset-angular": ">= 7"
-  },
-  "optionalDependencies": {
     "@angular/animations": ">= 6",
     "@angular/cli": ">= 6",
     "@angular/common": ">= 6",
     "@angular/core": ">= 6",
     "@angular/platform-browser-dynamic": ">= 6",
     "@angular/platform-server": ">= 6",
-    "@microsoft/typescript-etw": "*",
     "@types/lodash": ">= 4",
     "@types/node": ">= 8",
     "core-js": "*",
+    "jest-preset-angular": ">= 7",
     "rxjs": ">= 6",
     "zone.js": "*"
+  },
+  "optionalDependencies": {
+    "@microsoft/typescript-etw": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "nx": "nx",
     "start": "ng serve",
     "build": "ng build",
+    "preinstall": "node ./scripts/prevent-npm-install.js",
     "//": "Prebuilt libs help to control and test result of building before publication, but not usuable when you developing",
     "build:all-libs": "ng build oapi3ts && ng build ng-api-service && ng build oapi3ts-cli",
     "clear:prebuilt-libs": "rm -rf dist/*",

--- a/scripts/prevent-npm-install.js
+++ b/scripts/prevent-npm-install.js
@@ -1,0 +1,19 @@
+if (process.env.npm_execpath.indexOf('yarn') !== -1) {
+    process.exit(0);
+}
+
+console.error(`
+\x1b[31m
+╔══════════════════════════════════════╗
+║ ░ Please use Yarn, not NPM!          ║
+║ ░                                    ║
+║ ░ This project uses Yarn Workspaces, ║
+║ ░ but NPM can't install dependencies ║
+║ ░ of libraries in monorepository.    ║
+║                                      ║
+║ See: https://yarnpkg.com/            ║
+╚══════════════════════════════════════╝
+\x1b[0m
+`);
+
+process.exit(1);


### PR DESCRIPTION
Now some packages (`ng-api-service`, `oapi3ts` and `oapi3ts-cli`) have `@angular`-scope optional dependencies (or drive to them). This is why we have to install `@codegena/oapi3ts-cli` with `--no-optional` param:

```
npm i @codegena/oapi3ts-cli --no-optional
```

With this pull request all `@angular`-scoped dependencies will be moved to `devDependencies`.
