### PR TITLE
fix(oapi3ts): update supporting `nullable` option

### DIFF
--- a/libs/oapi3ts/src/lib/adapters/typescript/convertor.spec.ts
+++ b/libs/oapi3ts/src/lib/adapters/typescript/convertor.spec.ts
@@ -88,8 +88,8 @@ describe('Typescript convertor isolated schema\'s rendering', () => {
                 .replace(/\s+/g, ' ').trim();
 
             expect(renderedObject).toBe([
-                '{ firstProperty: number; secondProperty: string; thirdProperty:',
-                '{ [key: string]: any }; /** * Auto filled property from `required`',
+                '{ firstProperty: number; secondProperty: string; thirdProperty: null |',
+                '{ [key: string]: any } ; /** * Auto filled property from `required`',
                 '*/ fourthProperty: any }'
             ].join(' '));
         }

--- a/libs/oapi3ts/src/lib/adapters/typescript/descriptors/object.ts
+++ b/libs/oapi3ts/src/lib/adapters/typescript/descriptors/object.ts
@@ -102,6 +102,15 @@ export class ObjectTypeScriptDescriptor
                         /^./, propName[0].toUpperCase()
                     );
 
+                if (propSchema && propSchema.nullable && propSchema.type) {
+                    propSchema = {
+                        oneOf: [
+                            { type: 'null'},
+                            _.omit(propSchema, 'nullable')
+                        ]
+                    } as any; // todo describe oneOf for base schema
+                }
+
                 const typeContainer = convertor.convert(
                     propSchema,
                     context,

--- a/libs/oapi3ts/src/lib/adapters/typescript/mocks/isolated-schemas.json
+++ b/libs/oapi3ts/src/lib/adapters/typescript/mocks/isolated-schemas.json
@@ -25,7 +25,8 @@
           "type": "string"
         },
         "thirdProperty": {
-          "type": "object"
+          "type": "object",
+          "nullable": true
         }
       },
       "required": [

--- a/libs/oapi3ts/src/lib/core/convertor.spec.ts
+++ b/libs/oapi3ts/src/lib/core/convertor.spec.ts
@@ -57,7 +57,6 @@ describe('BaseConvertor entry points extracting', () => {
         expect(methodMeta.requestIsRequired).toBeFalsy();
         expect(methodMeta.queryParams).toEqual([
             'importantProperty',
-            "nullableProperty",
             'optionalProperty'
         ]);
         // Important! typingsDependencies should be empty

--- a/libs/oapi3ts/src/lib/core/convertor.ts
+++ b/libs/oapi3ts/src/lib/core/convertor.ts
@@ -524,15 +524,6 @@ export abstract class BaseConvertor {
             }
 
             if (parameter.schema) {
-                if (parameter.schema.nullable && parameter.schema.type) {
-                    parameter.schema = {
-                        oneOf: [
-                            { type: 'null'},
-                            _.omit(parameter.schema, 'nullable')
-                        ]
-                    } as any; // todo describe oneOf for base schema
-                }
-
                 paramsSchema.properties[parameter.name] = parameter.schema;
 
                 if (parameter.description) {

--- a/libs/oapi3ts/src/lib/core/mocks/oas3/01-case-simplest-get.json
+++ b/libs/oapi3ts/src/lib/core/mocks/oas3/01-case-simplest-get.json
@@ -21,16 +21,6 @@
             }
           },
           {
-            "name": "nullableProperty",
-            "in": "query",
-            "description": "Important query parameter",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          {
             "name": "optionalProperty",
             "in": "query",
             "description": "Optional query parameter",


### PR DESCRIPTION
Previous support of `nullable` relied on entrypoint params preconverting. Now it relies on object type descriptor.

closes #39